### PR TITLE
show/hide details, sort by newest/oldest first

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,7 @@ If you are in the Digital Marketplace and want to update the existing deployment
 Guidance](https://docs.cloud.service.gov.uk/#setting-up-the-command-line) for how to login, then run `cf push` from
 the root of this directory. The Trello Developer key is stored in the dm-credentials repository under 
 `vars/trello.yaml`; if it ever changes, use `cf set-env` to update it.
+
+## Testing changes
+Deploy to a personal heroku account or PaaS sandbox and integrate with a personal board. Yep... I've come up with
+nothing better in the few seconds I spent thinking about it.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"swig": "1.4.2"
 	},
 	"engines": {
-		"node": "6.10.2"
+		"node": "6.11.1"
 	},
 	"keywords": [
 		"node",

--- a/public/css/overlay.css
+++ b/public/css/overlay.css
@@ -12,3 +12,24 @@ body {
   max-width: 600px;
   max-height: 90%;
 }
+
+.history-config {
+}
+
+.hide {
+  display: none;
+}
+
+.history-config {
+  display: table;
+}
+
+.history-config > p.settings {
+  display: inline;
+}
+
+.history-config > div.settings {
+  display: table-cell;
+  text-align: center;
+  width: 50%;
+}

--- a/public/js/activity-builder.js
+++ b/public/js/activity-builder.js
@@ -8,6 +8,8 @@ function ActivityBuilder() {
 */
 ActivityBuilder.prototype._buildItemFromElements = function _buildItemFromElements(item, modType, divDesc) {
   var parent = document.createElement('DIV');
+  parent.dataset.datetime = item.date;
+  parent.dataset.type = item.type;
 
   parent.classList.add('phenom');
   parent.classList.add('mod-' + modType + '-type');

--- a/public/js/overlay.js
+++ b/public/js/overlay.js
@@ -37,3 +37,41 @@ document.addEventListener('keyup', function(e) {
     t.closeOverlay().done();
   }
 });
+
+toggleDetails = function() {
+  $(this).toggleClass('hide');
+  $(this).siblings().toggleClass('hide');
+
+  if ($(this).hasClass('js-show-everything')) {
+    $('div.mod-other-type').removeClass('hide');
+  }
+  else
+  {
+    $('div#subcontent > div').each(function () {
+      if (this.dataset.type != 'commentCard') {
+        $(this).addClass('hide');
+      }
+    });
+  }
+}
+
+toggleChronology = function() {
+  $(this).toggleClass('hide');
+  $(this).siblings().toggleClass('hide');
+
+  $parent = $('div#subcontent');
+  $divs = $parent.children('div')
+  if ($(this).hasClass('js-newest-first')) {
+    $divs.sort(function (a,b) {return new Date(b.dataset.datetime) - new Date(a.dataset.datetime);});
+  }
+  else
+  {
+    $divs.sort(function (a,b) {return new Date(a.dataset.datetime) - new Date(b.dataset.datetime);});
+  }
+  $divs.detach().appendTo($parent)
+}
+
+$('.js-show-everything').click(toggleDetails);
+$('.js-show-comments-only').click(toggleDetails);
+$('.js-newest-first').click(toggleChronology);
+$('.js-oldest-first').click(toggleChronology);

--- a/public/overlay.html
+++ b/public/overlay.html
@@ -11,6 +11,17 @@
         <span class="window-module-title-icon icon-lg icon-activity"></span>
         <h2>Card History</h2>
       </div>
+      <div class="history-config">
+        <p class="settings">Settings: </p>
+        <div class="settings">
+          <a class="js-newest-first hide" href="#">Show newest first</a>
+          <a class="js-oldest-first" href="#">Show oldest first</a>
+        </div>
+        <div class="settings">
+          <a class="js-show-everything hide" href="#">Show everything</a>
+          <a class="js-show-comments-only" href="#">Show only comments</a>
+        </div>
+      </div>
       <div id="subcontent">
         <p>
           Loading full history...


### PR DESCRIPTION
## Summary
Adds two links to the top of the overlay allowing you to sort items by newest/oldest item first, and also to only show the comments on the card (e.g. both together allow you to view conversations in chronological order).

Also bumping node version, because PaaS complained.

You'll just have to trust me that it works. Quality code!!! And/or you can test it on your local Trello board. I've pushed the update out already.

I love following processes.

## Todo?
Store preferences so it retains chosen settings across calls?

## Example
![show hide filter](https://user-images.githubusercontent.com/2920760/29387256-153dfcfe-82d7-11e7-8792-c66c1411528b.gif)
